### PR TITLE
User can now delete their own messages

### DIFF
--- a/src/components/messages/MessageCard.js
+++ b/src/components/messages/MessageCard.js
@@ -2,16 +2,25 @@
 
 //This module is responsible for rendering date from individual message objects to the DOM, and will only be called from MessageList.js
 
-import React from 'react'
+import React, { useContext } from 'react'
 import './MessageCard.css'
+import { MessageContext } from './MessageProvider'
 
 export const MessageCard = ({ message, currentUser }) => {
+    const { deleteMessage } = useContext(MessageContext)
     let userButtons
+
+    const handleDelete = () => {
+        deleteMessage(message.id)
+    }
+
     if (currentUser) {
         userButtons =
             <div className="message__buttons">
                 <button className="button btn--edit">Edit</button>
-                <button className="button btn--delete">Delete</button>
+                <button className="button btn--delete"
+                    onClick={handleDelete}
+                >Delete</button>
             </div>
     }
     return (


### PR DESCRIPTION
# Message Delete

delete button on message now works properly

Closes #15 

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] This change requires a documentation update

## Testing

- run a json-server

```
git fetch ram-messages-delete
npm start
```

Logged in user, on click "delete":
- [ ] message disappears from DOM
- [ ] Message has been wiped from API
- [ ] user can add another message
- [ ] user can immediately delete new message as above
