### PR TITLE
Events - "Up Next"

### DIFF
--- a/src/components/events/EventCard.css
+++ b/src/components/events/EventCard.css
@@ -6,3 +6,13 @@
 .event > button {
     align-self: flex-end;
 }
+
+.next {
+    background-color: wheat;
+    font-weight: bold;
+}
+
+.next > h2 {
+    font-weight: bold;
+}
+

--- a/src/components/events/EventCard.js
+++ b/src/components/events/EventCard.js
@@ -6,7 +6,7 @@ import React, { useContext } from 'react'
 import './EventCard.css'
 import { EventContext } from './EventProvider'
 
-export const EventCard = ({ event }) => {
+export const EventCard = ({ event, special }) => {
     const { deleteEvent } = useContext(EventContext)
 
     const handleClickDeleteButton = () => {
@@ -15,9 +15,10 @@ export const EventCard = ({ event }) => {
 
 
     return (
-        <article className="event">
+        <article className={special ? "event next" : "event"}>
             <h2 className="event__name">{event.name}</h2>
             <p className="event__date">{event.date}</p>
+            <p>{special ? "Special!!" : "Not Special"}</p>
             <p className="event__location">{event.city}, {event.state}</p>
             <button className="event__weatherButton button">Show Weather</button>
             <button className="event__deleteButton button btn--delete"

--- a/src/components/events/EventList.js
+++ b/src/components/events/EventList.js
@@ -32,7 +32,12 @@ export const EventList = () => {
             <button onClick={() => history.push(`/events/create`)} id="addEventButton" className="button btn-create">Add an Event</button>
             {
                 sortedEvents.map(event => {
-                    return <EventCard key={event.id} event={event} />
+                    const upNext = sortedEvents.filter(event => {
+                        const rightNow = Date.now()
+                        return new Date(event.date).valueOf() > rightNow
+                    })[0]
+                    const special = event === upNext
+                    return <EventCard key={event.id} event={event} special={special}/>
                 })
             }
         </section>


### PR DESCRIPTION
# Next chronological event has special styling

The "next up" event based on the event date is highlighted in a soft wheat-yellow, has bold text, and a bold H2

Closes #50 

## Type of change

- [x] New feature


## Testing

- run a json-server

```
git fetch (branch-name)
npm start
```

(this is easier to see if you have multiple events, one with a date that has already past)

- Given a user is logged in and on the "/events" view:
- [ ] The next chronological event is styled exclusively
- [ ] Events before and after this "up next" event remain boring with a white background and normal text
