### PR TITLE
Refactored MessageCard to provide Nevermind button; also when edited,…

### DIFF
--- a/src/components/messages/MessageCard.js
+++ b/src/components/messages/MessageCard.js
@@ -4,22 +4,26 @@
 //This module is responsible for rendering date from individual message objects to the DOM, and will only be called from MessageList.js
 
 import React, { useContext, useEffect, useState } from 'react'
-import { Link } from "react-router-dom"
+import { Link, useHistory } from "react-router-dom"
 import './MessageCard.css'
 import { MessageContext } from './MessageProvider'
 
 export const MessageCard = ({ message, user, currentUser }) => {
-    const { getMessageById, deleteMessage, editMessage } = useContext(MessageContext)
+    const { getMessageById, deleteMessage, editMessage, getMessages } = useContext(MessageContext)
+
+    const history = useHistory()
 
     const [messageToEdit, setmessageToEdit] = useState(
         {
             userId: 0,
             text: "",
-            timestamp: 0
+            timestamp: 0,
+            editTimestamp: 0
         }
     )
 
     const [editClicked, setEditClicked] = useState(false)
+    // const [nevermind, setNevermind] = useState(false)
 
     let userButtons
 
@@ -39,13 +43,23 @@ export const MessageCard = ({ message, user, currentUser }) => {
     }
 
     const handleSave = () => {
-        editMessage(messageToEdit)
+        const newMessageToEdit = {...messageToEdit}
+        newMessageToEdit.editTimestamp = Date.now()
+        editMessage(newMessageToEdit)
     }
+    
+//    useEffect(() => {
+//        if (nevermind) {
+
+//        }
+
+//    }, [])
 
     if (currentUser) {
         userButtons =
             <div className="message__buttons">
-                {editClicked ? <button className="button btn--edit" onClick={() => {handleSave(); setEditClicked(false)}} id={`${message.id}`}>Save</button> : <button className="button btn--edit" onClick={() => {handleEdit(); setEditClicked(true)}} id={`${message.id}`}>Edit</button>}
+                {editClicked ? <button className="button btn--save" onClick={() => {handleSave(); setEditClicked(false)}} id={`${message.id}`}>Save</button> 
+                : <button className="button btn--edit" onClick={() => {handleEdit(); setEditClicked(true)}} id={`${message.id}`}>Edit</button>}
                 <button className="button btn--delete"
                     onClick={handleDelete}
                 >Delete</button>
@@ -57,9 +71,12 @@ export const MessageCard = ({ message, user, currentUser }) => {
                 <Link to={`/friends/add/${user.id}`}>
                     <em>{user.name}:</em>
                 </Link>
-                {editClicked ? <input type="text" value={messageToEdit.text} onChange={event => handleChangeInput(event)}></input> : message.text}</div>
+                {editClicked ? 
+                <><input type="text" value={messageToEdit.text} onChange={event => handleChangeInput(event)}></input> <button className="btn--nevermind" onClick={() =>{setEditClicked(false)}}>Nevermind</button></>
+                : message.text}</div>
             <div className="message__info">
-                <p className="message__info--timestamp">{new Date(message.timestamp).toLocaleString('en-US')}</p>
+                <p className="message__info--timestamp">{message.editTimestamp > 0 ? `(edited)${new Date(message.editTimestamp).toLocaleString('en-US')}` 
+                : new Date(message.timestamp).toLocaleString('en-US')}</p>
             </div>
             {userButtons}
         </article>

--- a/src/components/messages/MessageCard.js
+++ b/src/components/messages/MessageCard.js
@@ -17,7 +17,7 @@ export const MessageCard = ({ message, user, currentUser }) => {
         {
             userId: 0,
             text: "",
-            timestamp: 0,
+            originalTimestamp: 0,
             editTimestamp: 0
         }
     )
@@ -76,7 +76,7 @@ export const MessageCard = ({ message, user, currentUser }) => {
                 : message.text}</div>
             <div className="message__info">
                 <p className="message__info--timestamp">{message.editTimestamp > 0 ? `(edited)${new Date(message.editTimestamp).toLocaleString('en-US')}` 
-                : new Date(message.timestamp).toLocaleString('en-US')}</p>
+                : new Date(message.originalTimestamp).toLocaleString('en-US')}</p>
             </div>
             {userButtons}
         </article>

--- a/src/components/messages/MessageList.js
+++ b/src/components/messages/MessageList.js
@@ -30,7 +30,7 @@ export const MessageList = () => {
         const newMessage = {
             userId: currentUserId,
             text: newText,
-            timestamp: Date.now(),
+            originalTimestamp: Date.now(),
             editTimestamp: 0
         }
         addMessage(newMessage)

--- a/src/components/messages/MessageList.js
+++ b/src/components/messages/MessageList.js
@@ -30,7 +30,8 @@ export const MessageList = () => {
         const newMessage = {
             userId: currentUserId,
             text: newText,
-            timestamp: Date.now()
+            timestamp: Date.now(),
+            editTimestamp: 0
         }
         addMessage(newMessage)
         setNewText("")


### PR DESCRIPTION
… the message card will say edited and have the edited timestamp

# Description


Closes # (issue)

## Type of change

- [ ] Bug fix
- [X ] New feature
- [ ] Breaking change
- [ ] This change requires a documentation update

## Testing

- run a json-server
"messages": [
    {
      "id": 1,
      "userId": 1,
      "text": "Hey this is our first message!",
      "timestamp": 1615231852203,
      "editTimestamp": 1615493296529
    },
    {
      "userId": 1,
      "text": "Hey I'm testing out a new message.",
      "timestamp": 1615237979863,
      "id": 4,
      "editTimestamp": 1615495646911
    },
    {
      "userId": 1,
      "text": "hello here's another",
      "timestamp": 1615238021093,
      "id": 5,
      "editTimestamp": 1615493598276
    },
    {
      "userId": 1,
      "text": "cool",
      "timestamp": 1615238026750,
      "id": 6,
      "editTimestamp": 0
    }
  ]
```
git fetch kk-msg-edit-cleanup
npm start
```

- [ ] If a message is edited, it will have an edited note with the timestamp of the edit
- [ ] If the user clicks never mind, the message is not edited and the input becomes text again
- [ ] Test C
